### PR TITLE
Fix latest posts list links

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -4,6 +4,8 @@ url: https://chen-qingxiang.github.io
 language: en
 timezone: Australia/Sydney
 permalink: /blog/:title/
+# Publish scheduled posts so upcoming work can be previewed publicly
+future: true
 # GitHub Pages built-in theme
 theme: jekyll-theme-cayman
 # Optional: add more metadata later (twitter, linkedin, etc.)

--- a/index.md
+++ b/index.md
@@ -13,11 +13,10 @@ I build simple tools that make learning and research smoother. This site hosts m
 
 
 ## Latest posts
-<ul>
+{% if site.posts.size > 0 %}
 {% for post in site.posts limit:10 %}
-<li>
-<a href="{{ post.url | relative_url }}">{{ post.title }}</a>
-<small> — {{ post.date | date: "%Y-%m-%d" }}</small>
-</li>
+- [{{ post.title }}]({{ post.url | relative_url }}) — {{ post.date | date: "%Y-%m-%d" }}
 {% endfor %}
-</ul>
+{% else %}
+_No posts published yet._
+{% endif %}


### PR DESCRIPTION
## Summary
- render the latest posts section with Markdown links so titles remain clickable in the Cayman theme
- enable publication of future-dated posts so scheduled articles are accessible

## Testing
- not run (not available in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68e4d858f3d083328c7d2021731c7e78